### PR TITLE
Fix scroll up motion on header

### DIFF
--- a/motionlayout/src/main/res/xml/scene_17_header.xml
+++ b/motionlayout/src/main/res/xml/scene_17_header.xml
@@ -22,10 +22,6 @@
         motion:constraintSetEnd="@+id/end"
         motion:duration="1000"
         motion:motionInterpolator="linear">
-        <OnSwipe
-            motion:touchAnchorId="@+id/background"
-            motion:touchAnchorSide="bottom"
-            motion:dragDirection="dragUp" />
 
         <ConstraintSet android:id="@+id/start">
             <Constraint


### PR DESCRIPTION
Removed useless swipe listener on header which was eating touch and causing parent motion layout to not scroll up if you swipe up in header area.